### PR TITLE
Fix: Correct url_for endpoint names in base.html navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,18 +13,18 @@
 <body>
     <header>
         <div class="header-content">
-            <a href="{{ url_for('main.home') }}"> {# Reverted to main.home #}
+            <a href="{{ url_for('home') }}"> {# Corrected to 'home' #}
                 <img src="{{ url_for('static', filename='logo.png') }}" alt="PrayReps Logo" class="logo">
             </a>
             <h1>{% block page_title %}Praying for Representatives{% endblock %}</h1>
         </div>
         <nav>
             <ul>
-                <li><a href="{{ url_for('main.home') }}">Home</a></li> {# Reverted to main.home #}
-                <li><a href="{{ url_for('prayer.queue_page_html') }}">Queue</a></li>
-                <li><a href="{{ url_for('prayer.prayed_list_default_redirect') }}">Prayed List</a></li>
-                <li><a href="{{ url_for('stats.statistics_default_redirect') }}">Statistics</a></li>
-                <li><a href="{{ url_for('main.about_page') }}">About</a></li>
+                <li><a href="{{ url_for('home') }}">Home</a></li> {# Corrected to 'home' #}
+                <li><a href="{{ url_for('queue_page') }}">Queue</a></li>
+                <li><a href="{{ url_for('prayed_list') }}">Prayed List</a></li>
+                <li><a href="{{ url_for('statistics') }}">Statistics</a></li>
+                <li><a href="{{ url_for('home') }}">About</a></li> {# Pointing 'About' to home for now #}
             </ul>
         </nav>
     </header>
@@ -37,7 +37,7 @@
     <footer>
         <p>&copy; {{ now.year }} PrayReps Project.
             Inspired by the <a href="https://kingdomdemocracy.global/" target="_blank" rel="noopener noreferrer">Kingdom Democracy Project</a>.
-             | <a href="{{ url_for('main.about_page') }}">About PrayReps</a>
+             | <a href="{{ url_for('home') }}">About PrayReps</a> {# Pointing 'About' to home for now #}
         </p>
     </footer>
 


### PR DESCRIPTION
Updated url_for calls in templates/base.html to use direct endpoint names (e.g., 'home', 'queue_page', 'prayed_list', 'statistics') instead of incorrect Blueprint-prefixed names.

This aligns with app.py where these routes are defined directly on the Flask app object and no Blueprints named 'main', 'prayer', or 'stats' are registered. The 'About' link in the header and footer now temporarily points to the 'home' endpoint as no 'about_page' route was found in app.py.