### PR TITLE
Fix BuildError for about_page link in templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -683,6 +683,15 @@ def update_queue():
                 logging.debug("SQLite connection closed in update_queue.")
         # The while True loop and time.sleep(90) are removed.
 
+@app.route('/about')
+def about_page():
+    """Renders the about page."""
+    logging.info("Serving about page from app.py")
+    # This mirrors the about_page from project/blueprints/main.py
+    # Ensure templates/about.html exists and is appropriate.
+    now = datetime.now()
+    return render_template('about.html', now=now)
+
 def load_prayed_for_data_from_db():
     """Loads all prayed-for items from the SQLite database into the global prayed_for_data."""
     global prayed_for_data

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
                 <li><a href="{{ url_for('queue_page') }}">Queue</a></li>
                 <li><a href="{{ url_for('prayed_list') }}">Prayed List</a></li>
                 <li><a href="{{ url_for('statistics') }}">Statistics</a></li>
-                <li><a href="{{ url_for('home') }}">About</a></li> {# Pointing 'About' to home for now #}
+                <li><a href="{{ url_for('about_page') }}">About</a></li>
             </ul>
         </nav>
     </header>
@@ -38,7 +38,7 @@
     <footer>
         <p>&copy; {{ now.year }} PrayReps Project.
             Inspired by the <a href="https://kingdomdemocracy.global/" target="_blank" rel="noopener noreferrer">Kingdom Democracy Project</a>.
-             | <a href="{{ url_for('home') }}">About PrayReps</a> {# Pointing 'About' to home for now #}
+             | <a href="{{ url_for('about_page') }}">About PrayReps</a>
         </p>
     </footer>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
 {% block content %}
     <div class="intro-text">
         <p>Welcome to PrayReps! We're glad you're here to pray for the elected representatives of <strong>Israel</strong> and <strong>Iran</strong>.</p>
-        <p>Below, you'll see one representative at a time. Take a moment to pray for them, then click "🙏 Amen" to move to the next person. The map will update to show who you've prayed for. For more information, check out the <a href="{{ url_for('main.about_page') }}">About page</a>.</p>
+        <p>Below, you'll see one representative at a time. Take a moment to pray for them, then click "🙏 Amen" to move to the next person. The map will update to show who you've prayed for. For more information, check out the <a href="{{ url_for('about_page') }}">About page</a>.</p>
     </div>
 
     {# This div will be updated by HTMX after processing an item via OOB swap #}


### PR DESCRIPTION
- Add an /about route to app.py to ensure an endpoint is available if app.py is the effective runtime environment.
- Update url_for('main.about_page') to url_for('about_page') in templates/index.html and templates/base.html.

This resolves the werkzeug.routing.exceptions.BuildError caused by 'main.about_page' not being found when app.py's routes are active.