### PR TITLE
Fix Jinja errors and improve base styling

### DIFF
--- a/project/blueprints/prayer.py
+++ b/project/blueprints/prayer.py
@@ -165,7 +165,8 @@ def get_queue_json():
 @bp.route('/queue_page')
 def queue_page_html():
     items = prayer_service.get_queued_representatives()
-    return render_template('queue.html', queue=items)
+    now = datetime.now()
+    return render_template('queue.html', queue=items, now=now)
 
 # Non-HTMX version of process_item, similar to original app.py version
 @bp.route('/process_item_form', methods=['POST'])
@@ -293,10 +294,12 @@ def prayed_list_page_html(country_code):
         prayed_for_list_to_render = prayed_list_display_specific
         current_country_name = current_app.config['COUNTRIES_CONFIG'][country_code]['name']
 
+    now = datetime.now()
     return render_template('prayed.html',
                            prayed_for_list=prayed_for_list_to_render,
                            country_code=country_code,
-                           country_name=current_country_name
+                           country_name=current_country_name,
+                           now=now
                            )
 
 @bp.route('/')

--- a/project/blueprints/stats.py
+++ b/project/blueprints/stats.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, current_app, jsonify, redirect, url_for
+from datetime import datetime
 import os
 import sys
 import json
@@ -41,11 +42,13 @@ def statistics_page(country_code):
     # The main statistics.html page will setup containers for charts.
     # Actual data is fetched by client-side JS using the JSON endpoints below.
     # We pass initial config data that JS might need, like party colors.
+    now = datetime.now()
     return render_template('statistics.html',
                            country_code=country_code,
                            country_name=current_country_name,
                            # Pass party color mapping for the selected country to JS via data attribute or JS var
-                           current_country_party_info_json=json.dumps(current_party_info_map_for_js)
+                           current_country_party_info_json=json.dumps(current_party_info_map_for_js),
+                           now=now
                            )
 
 @bp.route('/')

--- a/static/style.css
+++ b/static/style.css
@@ -4,7 +4,8 @@ body {
     background-color: #f0f0f0;
 }
 
-.content {
+/* Base container for consistent padding, width, etc. */
+.content-container {
     margin: 20px auto;
     padding: 20px;
     background-color: white;
@@ -13,6 +14,13 @@ body {
     width: 80%;
     max-width: 1200px;
 }
+
+/* Modifier for flex behavior, used on index.html */
+.content-container--flex {
+    display: flex;
+    justify-content: space-between; /* Existing behavior from .columns or second .content */
+}
+
 
 .sentence-box {
     display: flex;
@@ -149,37 +157,50 @@ body {
 .other { background-color: #CCCCCC; }
 
 /* Layout */
+/* .columns class can be removed if .content-container--flex replaces its usage */
+/*
 .columns {
     display: flex;
     justify-content: space-between;
     margin: 20px 0;
 }
-
-.column {
+*/
+.column { /* This might still be used within a flex container */
     flex: 1;
     padding: 10px;
 }
 
 /* General Styles */
-.content {
-    display: flex;
-    margin: 20px auto;
-    padding: 20px;
-    background-color: white;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    width: 80%;
-    max-width: 1200px;
+/* .content class is now replaced by .content-container and .content-container--flex */
+
+/* Ensure these specific content types inherit from .content-container */
+/* If they have no unique styles, they can just use class="content-container" in HTML */
+/* For now, let's assume they might have specific styles later, so we keep the class names */
+.prayedcontent {
+    /* Inherits from .content-container. Add specific styles here if needed. */
 }
 
-.prayedcontent, .statscontent, .queuecontent {
-    margin: 20px auto;
-    padding: 20px;
-    background-color: white;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    width: 80%;
-    max-width: 1200px;
+.statscontent {
+    /* Inherits from .content-container. Add specific styles here if needed. */
+}
+
+.queuecontent {
+    /* Inherits from .content-container. Add specific styles here if needed. */
+}
+
+/* For text-heavy content containers like About page and intro text */
+.text-content, .intro-text {
+    text-align: left;
+    max-width: 800px; /* Or whatever feels right for reading width */
+    margin-left: auto; /* Center the text block if its max-width is less than parent */
+    margin-right: auto;
+}
+
+.intro-text { /* Specific margins for the intro on home page */
+    margin-bottom: 30px;
+    padding: 15px;
+    background-color: #e9ecef; /* A slightly different background to distinguish it */
+    border-radius: 6px;
 }
 
 .sentence-box {
@@ -187,8 +208,9 @@ body {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin: 40px 0;
-    font-size: 3em;
+    margin: 20px 0; /* Reduced top/bottom margin slightly */
+    font-size: 2em; /* Reduced font size */
+    font-weight: normal; /* Was missing, but present in an earlier definition */
 }
 
 .profile {

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
         {% include 'partials/_stats_summary.html' with context %}
     </div>
 
-    <div class="content">
+    <div class="content-container content-container--flex">
         <div class="left-content">
             {# This div is the primary target for the Amen button's HTMX POST.
                It will be replaced by the response from process_item_htmx,

--- a/templates/prayed.html
+++ b/templates/prayed.html
@@ -5,7 +5,7 @@
 {% block page_title %}Prayed List for {{ country_name }}{% endblock %}
 
 {% block content %}
-    <div class="prayedcontent content-container">
+    <div class="content-container prayedcontent">
         {# Links are now in base.html nav, but we can have page-specific actions here #}
         <div class="page-actions">
             <button id="toggleAffiliationButton" onclick="togglePartyAffiliation()">Show/Hide Party Colors</button>

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -5,7 +5,7 @@
 {% block page_title %}Prayer Queue (All Countries){% endblock %}
 
 {% block content %}
-    <div class="queuecontent content-container">
+    <div class="content-container queuecontent">
         {# Main navigation links are now in base.html header #}
         {# This page might not need additional page-specific actions beyond the list itself #}
 

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="statscontent content-container">
+    <div class="content-container statscontent">
         {# Main navigation links are in base.html header #}
         <div class="country-switch-links">
             Switch to:
@@ -43,5 +43,4 @@
             <canvas id="partyChart"></canvas>
         </div>
     </div>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
- Resolved `UndefinedError: 'now' is undefined` in several templates by passing the 'now' context variable from their respective view functions.
- Fixed `TemplateSyntaxError` in `statistics.html` by correcting block termination.
- Consolidated common CSS container styles into `.content-container` and updated templates to use this class.
- Improved readability of narrative text sections with left-alignment and better width constraints.
- Reduced an overly large font size for the main sentence box.
- Notified user about missing `logo.png` (404 error).